### PR TITLE
bug(social):Fix a bug in twitter login

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ import bodyParser from 'body-parser';
 import errorhandler from 'errorhandler';
 import cors from 'cors';
 import passport from 'passport';
+import session from 'express-session';
 import routes from './routes';
 import registerApiDocEndpoint from './config/swagger';
 import pass from './config/passport/localstrategy';
@@ -14,6 +15,16 @@ const isProduction = process.env.NODE_ENV === 'production';
 const app = express();
 
 app.use(cors());
+
+app.use(
+  session({
+    secret: process.env.SECRET,
+    cookie: { maxAge: 60000 },
+    resave: true,
+    saveUninitialized: true
+  })
+);
+
 
 // Normal express config defaults
 app.use(bodyParser.urlencoded({ extended: false }));


### PR DESCRIPTION
#### Description

Twitter authentication differs from another social network because it uses passport-oauth1 for authentication while others use passport-oauth2. So, twitter authentication needs a requestTokenStore to store the token before the exchanging. And by default, it is SessionRequestTokenStore from passport-oauth1 which is in express session.

#### Type of change
Adding express session middleware 


#### Screenshot:
![image](https://user-images.githubusercontent.com/12936280/57602982-c8578580-7560-11e9-8c97-53c3090376a7.png)

#### Pivotal Tracker ID
[#165957840](https://www.pivotaltracker.com/n/projects/2326984/stories/165957840)