### PR TITLE
#165965800 remove user data on signup response

### DIFF
--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -70,14 +70,9 @@ class UserController {
   static async addUser(req, res) {
     passport.authenticate('local_signup', (err, user) => {
       if (user) {
-        const userData = {
-          id: user.id,
-          username: user.username,
-          email: user.email,
-        };
         const issueToken = helper.generateToken(user.dataValues);
         return res.status(201).send({
-          status: 201, message: 'User added successfully', token: issueToken, user: userData
+          status: 201, message: 'User added successfully', token: issueToken
         });
       }
       return res.status(500).send({ status: 500, message: 'Internal Server Error' });

--- a/tests/rate-article.test.js
+++ b/tests/rate-article.test.js
@@ -36,11 +36,6 @@ describe('Rate user posted article', () => {
       .end((err, res) => {
         toKen = res.body.token;
         expect(res.body).to.have.status(201);
-        expect(res.body.user).to.have.property('username').to.be.equal(userTest.username);
-        expect(res.body.user).to.have.property('email').to.be.equal(userTest.email);
-        expect(res.body.user.password).to.be.equal(undefined);
-        expect(res.body.user.email).to.not.be.equal('');
-        expect(res.body.user.password).to.not.be.equal('');
         expect(res.body).to.have.property('token').to.be.a('string');
         done();
       });
@@ -82,11 +77,6 @@ describe('Rate user posted article', () => {
       .end((err, res) => {
         toKen = res.body.token;
         expect(res.body).to.have.status(201);
-        expect(res.body.user).to.have.property('username').to.be.equal(anotherUsertest.username);
-        expect(res.body.user).to.have.property('email').to.be.equal(anotherUsertest.email);
-        expect(res.body.user.password).to.be.equal(undefined);
-        expect(res.body.user.email).to.not.be.equal('');
-        expect(res.body.user.password).to.not.be.equal('');
         expect(res.body).to.have.property('token').to.be.a('string');
         done();
       });

--- a/tests/user.test.js
+++ b/tests/user.test.js
@@ -27,12 +27,8 @@ describe('Users Authentication', () => {
       .send(user)
       .end((err, res) => {
         expect(res.body).to.have.status(201);
-        expect(res.body.user).to.have.property('username').to.be.equal(user.username);
-        expect(res.body.user).to.have.property('email').to.be.equal(user.email);
-        expect(res.body.user.password).to.be.equal(undefined);
-        expect(res.body.user.email).to.not.be.equal('');
-        expect(res.body.user.password).to.not.be.equal('');
         expect(res.body).to.have.property('token').to.be.a('string');
+        expect(res.body.token).to.not.be.equal('');
         done();
       });
   });


### PR DESCRIPTION
Description
=======
We need to refactor the response got when signing up by removing user data information for privacy purpose. We just expect the response to have the user token and a message for successful registration.

Type of change
=======
- Removed user data on the response in the controller
- change expected responses on user signup test

How has it been tested
=======
- It is tested when you signup via ```api/v1/users/signup```

Checklist:
=======
N/A

Pivotal tracker story ID
=======
[165965800](https://www.pivotaltracker.com/n/projects/2326984/stories/165965800)