### PR TITLE
#166065177 change response when user change password

### DIFF
--- a/controllers/resetPassword.js
+++ b/controllers/resetPassword.js
@@ -21,9 +21,13 @@ class Password {
     if (newPassword.trim() !== confirmNewPassword.trim()) {
       return res.status(401).send({ message: 'new password and confirm new password must be equal' });
     }
+    const validatedPassword = Helper.passwordValidator(newPassword);
+    if (validatedPassword !== true) {
+      return res.status(400).send({ message: validatedPassword });
+    }
     const hash = Helper.hashPassword(newPassword);
     User.update({ password: hash }, { where: { id: req.user.id } })
-      .then(result => res.status(201).send({ RESULT: result }))
+      .then(() => res.status(201).send({ message: 'Your password has been updated successfuly' }))
       .catch(error => res.status(400).send({ ERROR: error }));
   }
 

--- a/tests/resetPasswordTest.js
+++ b/tests/resetPasswordTest.js
@@ -70,10 +70,27 @@ describe('should reset password with email', () => {
         done();
       });
   });
+  it('should reset the password to newPassword only if it is valid', (done) => {
+    const data = {
+      newPassword: 'password!',
+      confirmNewPassword: 'password!'
+    };
+    chai
+      .request(app)
+      .post('/api/v1/users/resetPassword')
+      .set('authorization', token)
+      .send(data)
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.body.should.be.a('object');
+        res.body.should.have.property('message');
+        done();
+      });
+  });
   it('should reset the password to newPassword', (done) => {
     const data = {
-      newPassword: 'password',
-      confirmNewPassword: 'password'
+      newPassword: 'Password@123!',
+      confirmNewPassword: 'Password@123!'
     };
     chai
       .request(app)
@@ -83,8 +100,7 @@ describe('should reset password with email', () => {
       .end((err, res) => {
         res.should.have.status(201);
         res.body.should.be.a('object');
-        res.body.should.have.property('RESULT');
-        res.body.RESULT[0].should.be.eql(1);
+        res.body.should.have.property('message').eql('Your password has been updated successfuly');
         done();
       });
   });


### PR DESCRIPTION
Description
=======
We need to refactor the response got when changing the password to a more descriptive one. 

Type of change
=======
- Removed the default sequelize response for the update query
- put a more clear message of what is happening

How has it been tested
=======
- It is tested when you signup via ```api/v1/users/resetPassword ```

Checklist:
=======
N/A

Pivotal tracker story ID
=======
[#166065177](https://www.pivotaltracker.com/story/show/166065177)