### PR TITLE
#165413109 pagination for article ratings

### DIFF
--- a/helpers/articleRatevalidator.js
+++ b/helpers/articleRatevalidator.js
@@ -52,13 +52,30 @@ class ArticleRatelehelper {
      */
   static async getRating(req) {
     const { slug } = req.params;
+    const errorMessage = [];
     const getArticle = await Article.findOne({
       where: { slug }
     });
     if (getArticle == null) {
       return { status: 404, errors: 'This article does not exist' };
     }
+    let { limit, offset } = req.query;
+    if (limit === undefined || offset === undefined) {
+      limit = 20;
+      offset = 0;
+    }
+    if (!/^(0|[1-9]\d*)$/.test(limit) && limit !== undefined) {
+      errorMessage.push('Limit must be a number');
+    }
+    if (!/^(0|[1-9]\d*)$/.test(offset) && offset !== undefined) {
+      errorMessage.push('Offset must be a number');
+    }
+    if (errorMessage.length) {
+      return { status: 400, errors: { body: errorMessage } };
+    }
     const getRate = await Rating.findAll({
+      limit,
+      offset,
       where: { articleSlug: slug },
       include: [{ model: User, as: 'author', attributes: ['username', 'bio', 'image'] }]
     });

--- a/tests/rate-article.test.js
+++ b/tests/rate-article.test.js
@@ -217,4 +217,42 @@ describe('Rate user posted article', () => {
         done();
       });
   });
+  it('Rating pagination', (done) => {
+    chai.request(app)
+      .get(`/api/v1/articles/${articleSlug}/rate?limit=5&offset=0`)
+      .set('authorization', toKen)
+      .end((error, res) => {
+        expect(res.body).to.have.status(200);
+        expect(res.body.ratings[0]).to.have.property('id');
+        expect(res.body.ratings[0]).to.have.property('reviewerId');
+        expect(res.body.ratings[0]).to.have.property('articleSlug');
+        expect(res.body.ratings[0]).to.have.property('rate');
+        expect(res.body.ratings[0]).to.have.property('createdAt');
+        expect(res.body.ratings[0]).to.have.property('updatedAt');
+        expect(res.body.ratings[0]).to.have.property('author');
+        done();
+      });
+  });
+  it('Rating pagination limit must be a number', (done) => {
+    chai.request(app)
+      .get(`/api/v1/articles/${articleSlug}/rate?limit=y&offset=0`)
+      .set('authorization', toKen)
+      .end((error, res) => {
+        expect(res.body).to.have.status(400);
+        expect(res.body).to.have.property('errors');
+        expect(res.body.errors.body[0]).to.be.equal('Limit must be a number');
+        done();
+      });
+  });
+  it('Rating pagination limit must be a number', (done) => {
+    chai.request(app)
+      .get(`/api/v1/articles/${articleSlug}/rate?limit=1&offset=t`)
+      .set('authorization', toKen)
+      .end((error, res) => {
+        expect(res.body).to.have.status(400);
+        expect(res.body).to.have.property('errors');
+        expect(res.body.errors.body[0]).to.be.equal('Offset must be a number');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
Description
=======
When fetching or viewing many different data there can take place overloading of data. this feature enables to paginate a certain desired number of article's ratings. This solution avoids this issue of overloading of data.

Type of change
=======
N/A

How has it been tested
=======
- It is tested a GET method via this URL ```api/v1/articles/<article-slug>/rate?limit=digit&offset=digit```

Checklist:
=======
N/A

Pivotal tracker story ID
=======
[165413109](https://www.pivotaltracker.com/n/projects/2326984/stories/165413109)