### PR TITLE
#166161652 remove time functionality in comment feature

### DIFF
--- a/controllers/comment.controller.js
+++ b/controllers/comment.controller.js
@@ -16,7 +16,7 @@ class Comments {
   */
   static async addComment(req, res) {
     const result = await commentHelper.createComment(req);
-    return res.status(201).send(result);
+    return res.status(201).send({ comment: result });
   }
 
   /**

--- a/helpers/commentHelper.js
+++ b/helpers/commentHelper.js
@@ -12,28 +12,6 @@ const {
  * */
 class CommentHelper {
   /**
-     * Check and return the previous comment's id
-     * @param {object} req - an object
-     * @param {object} res - an object
-     * @param {object} next - an object
-     * @return {integer} Returns previous comment's id
-     * @static
-     */
-  static async parentId(req, res, next) {
-    let maxId = 1;
-    await Comment.findAll().then((result) => {
-      // eslint-disable-next-line array-callback-return
-      result.map((comment) => {
-        if (comment.id > maxId) {
-          maxId = comment.id;
-        }
-      });
-    });
-    req.body.previousId = maxId;
-    next();
-  }
-
-  /**
      * Check if Article exist and comment body is there
      * @param {object} req - an object
      * @param {object} res - an object
@@ -73,7 +51,6 @@ class CommentHelper {
      *@return {object} Return the created comment
      */
   static async createComment(req) {
-    const parentID = req.body.previousId;
     const { slug } = req.params;
 
     const createdComment = await Comment.create({
@@ -84,22 +61,8 @@ class CommentHelper {
       updatedAt: new Date()
     });
 
-    const childComment = createdComment.toJSON();
-
-    const parentComment = await Comment.findOne({ where: { id: parentID } });
-    if (parentComment === null) {
-      return { message: 'this is the first comment', id: childComment.id, userId: req.user.id };
-    }
-    if (parentComment.userId !== childComment.userId) {
-      return childComment;
-    }
-    const range = childComment.createdAt.getTime() - parentComment.createdAt.getTime();
-
-    if (range <= 60000) {
-      await Comment.update({ parentid: parentID }, { where: { id: childComment.id } });
-      return { type: 'threadedComment comment created', timeRange: `${range} milliseconds` };
-    }
-    return { type: 'no threadedComment created', timeRange: `${range} milliseconds` };
+    const comment = createdComment.toJSON();
+    return comment;
   }
 
   /**

--- a/migrations/20190508132500-create-comment.js
+++ b/migrations/20190508132500-create-comment.js
@@ -6,9 +6,6 @@ const commentMigrations = {
       primaryKey: true,
       type: Sequelize.INTEGER
     },
-    parentid: {
-      type: Sequelize.INTEGER
-    },
     replyid: {
       type: Sequelize.INTEGER,
       onDelete: 'CASCADE',

--- a/models/comment.js
+++ b/models/comment.js
@@ -5,7 +5,6 @@ const comments = (sequelize, DataTypes) => {
       autoIncrement: true,
       primaryKey: true
     },
-    parentid: DataTypes.INTEGER,
     replyid: DataTypes.INTEGER,
     userId: {
       type: DataTypes.INTEGER,

--- a/routes/api/comment/comment.js
+++ b/routes/api/comment/comment.js
@@ -5,15 +5,15 @@ import commentHelper from '../../../helpers/commentHelper';
 
 const router = express.Router();
 
-router.post('/:slug/comments', Auth, commentHelper.parentId, commentHelper.isValid, comment.addComment);
+router.post('/:slug/comments', Auth, commentHelper.isValid, comment.addComment);
 router.get('/:slug/comments', Auth, comment.getComments);
 router.get('/:slug/comments/:id', Auth, comment.getOneComment);
 router.delete('/:slug/comments/:id', Auth, commentHelper.isCommentExist, comment.deleteOneComment);
-router.post('/:slug/comments/:id', Auth, commentHelper.isCommentExist, comment.updateOneComment);
-router.post('/:id/reply', Auth, commentHelper.commentExist, comment.replyComment);
-router.get('/:id/replies', Auth, comment.getCommentReplies);
-router.delete('/:id/reply/:replyId', Auth, commentHelper.isReplytExist, comment.deleteOneReply);
-router.post('/:id/reply/:replyId', Auth, commentHelper.isReplytExist, comment.updateOneReply);
+router.put('/:slug/comments/:id', Auth, commentHelper.isCommentExist, comment.updateOneComment);
+router.post('/comments/:id/reply', Auth, commentHelper.commentExist, comment.replyComment);
+router.get('/comments/:id/replies', Auth, comment.getCommentReplies);
+router.delete('/comments/:id/replies/:replyId', Auth, commentHelper.isReplytExist, comment.deleteOneReply);
+router.put('/comments/:id/replies/:replyId', Auth, commentHelper.isReplytExist, comment.updateOneReply);
 
 
 export default router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -19,7 +19,6 @@ router.use('/users/roles', roles);
 router.use('/login', auth);
 router.use('/articles', article);
 router.use('/article', comment);
-router.use('/comment', comment);
 router.use('/comments', likes);
 router.use((err, req, res, next) => {
   if (err.name === 'ValidationError') {


### PR DESCRIPTION
Description
=======
We need to refactor the way comments are created by removing the time constraint. the user can create comments independent of time 

Type of change
=======
- Removed the time functionality of relating comments created in the space of one minute by the same user

How has it been tested
=======
- It is tested when you signup via ```api/v1/article/{slug}/comments ```

Checklist:
=======
N/A

Pivotal tracker story ID
=======
[#166161652](https://www.pivotaltracker.com/story/show/166161652)